### PR TITLE
Incident template API implementation 5852 (#69)

### DIFF
--- a/incident/incident_template.go
+++ b/incident/incident_template.go
@@ -1,0 +1,35 @@
+package incident
+
+import "context"
+
+func (c *Client) CreateIncidentTemplate(context context.Context, request *CreateIncidentTemplateRequest) (*CreateIncidentTemplateResult, error) {
+	result := &CreateIncidentTemplateResult{}
+	if err := c.client.Exec(context, request, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *Client) UpdateIncidentTemplate(context context.Context, request *UpdateIncidentTemplateRequest) (*UpdateIncidentTemplateResult, error) {
+	result := &UpdateIncidentTemplateResult{}
+	if err := c.client.Exec(context, request, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *Client) DeleteIncidentTemplate(context context.Context, request *DeleteIncidentTemplateRequest) (*DeleteIncidentTemplateResult, error) {
+	result := &DeleteIncidentTemplateResult{}
+	if err := c.client.Exec(context, request, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (c *Client) GetIncidentTemplate(context context.Context, request *GetIncidentTemplateRequest) (*GetIncidentTemplateResult, error) {
+	result := &GetIncidentTemplateResult{}
+	if err := c.client.Exec(context, request, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/incident/incident_template_request.go
+++ b/incident/incident_template_request.go
@@ -1,0 +1,207 @@
+package incident
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+	"github.com/pkg/errors"
+)
+
+type CreateIncidentTemplateRequest struct {
+	client.BaseRequest
+	Name                  string                `json:"name"`
+	Message               string                `json:"message"`
+	Description           string                `json:"description,omitempty"`
+	Tags                  []string              `json:"tags,omitempty"`
+	Details               map[string]string     `json:"details,omitempty"`
+	Priority              Priority              `json:"priority"`
+	ImpactedServices      []string              `json:"impactedServices,omitempty"`
+	StakeholderProperties StakeholderProperties `json:"stakeholderProperties"`
+}
+
+func (r *CreateIncidentTemplateRequest) Validate() error {
+	if r.Name == "" {
+		return errors.New("Name property cannot be empty.")
+	}
+	if err := validateMessage(r.Message); err != nil {
+		return err
+	}
+	if err := validateDescription(r.Description); err != nil {
+		return err
+	}
+	if err := validatePriority(r.Priority); err != nil {
+		return err
+	}
+	if err := validateImpactedServices(r.ImpactedServices); err != nil {
+		return err
+	}
+	if err := validateStakeholderProperties(r.StakeholderProperties); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *CreateIncidentTemplateRequest) ResourcePath() string {
+	return "v1/incident-templates/"
+}
+
+func (r *CreateIncidentTemplateRequest) Method() string {
+	return http.MethodPost
+}
+
+type UpdateIncidentTemplateRequest struct {
+	client.BaseRequest
+	IncidentTemplateId    string                `json:"id"`
+	Name                  string                `json:"name"`
+	Message               string                `json:"message"`
+	Description           string                `json:"description,omitempty"`
+	Tags                  []string              `json:"tags,omitempty"`
+	Details               map[string]string     `json:"details,omitempty"`
+	Priority              Priority              `json:"priority"`
+	ImpactedServices      []string              `json:"impactedServices,omitempty"`
+	StakeholderProperties StakeholderProperties `json:"stakeholderProperties"`
+}
+
+func (r *UpdateIncidentTemplateRequest) Validate() error {
+	if err := validateIncidentTemplateId(r.IncidentTemplateId); err != nil {
+		return err
+	}
+	if r.Name == "" {
+		return errors.New("Name property cannot be empty.")
+	}
+	if err := validateMessage(r.Message); err != nil {
+		return err
+	}
+	if err := validateDescription(r.Description); err != nil {
+		return err
+	}
+	if err := validatePriority(r.Priority); err != nil {
+		return err
+	}
+	if err := validateImpactedServices(r.ImpactedServices); err != nil {
+		return err
+	}
+	if err := validateStakeholderProperties(r.StakeholderProperties); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *UpdateIncidentTemplateRequest) ResourcePath() string {
+	return "v1/incident-templates/" + r.IncidentTemplateId
+}
+
+func (r *UpdateIncidentTemplateRequest) Method() string {
+	return http.MethodPut
+}
+
+type DeleteIncidentTemplateRequest struct {
+	client.BaseRequest
+	IncidentTemplateId string `json:"id"`
+}
+
+func (r *DeleteIncidentTemplateRequest) Validate() error {
+	if err := validateIncidentTemplateId(r.IncidentTemplateId); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *DeleteIncidentTemplateRequest) ResourcePath() string {
+	return "v1/incident-templates/" + r.IncidentTemplateId
+}
+
+func (r *DeleteIncidentTemplateRequest) Method() string {
+	return http.MethodDelete
+}
+
+type GetIncidentTemplateRequest struct {
+	client.BaseRequest
+	Limit  int
+	Offset int
+	Order  Order
+}
+
+func (r *GetIncidentTemplateRequest) Validate() error {
+	return nil
+}
+
+func (r *GetIncidentTemplateRequest) ResourcePath() string {
+	return "v1/incident-templates"
+}
+
+func (r *GetIncidentTemplateRequest) Method() string {
+	return http.MethodGet
+}
+
+func (r *GetIncidentTemplateRequest) RequestParams() map[string]string {
+	params := make(map[string]string)
+	if r.Limit != 0 {
+		params["limit"] = strconv.Itoa(r.Limit)
+	}
+	if r.Order != "" {
+		params["order"] = string(r.Order)
+	}
+	if r.Offset != 0 {
+		params["offset"] = strconv.Itoa(r.Offset)
+	}
+	return params
+}
+
+type StakeholderProperties struct {
+	Enable      *bool  `json:"enable,omitempty"`
+	Message     string `json:"message"`
+	Description string `json:"description,omitempty"`
+}
+
+func validateMessage(message string) error {
+	if message == "" {
+		return errors.New("Message property cannot be empty.")
+	} else if len(message) > 130 {
+		return errors.New("Message property cannot be longer than 130 characters.")
+	}
+	return nil
+}
+
+func validateDescription(description string) error {
+	if description != "" && len(description) > 1000 {
+		return errors.New("Description property cannot be longer than 1000 characters.")
+	}
+	return nil
+}
+
+func validatePriority(priority Priority) error {
+	switch priority {
+	case P1, P2, P3, P4, P5:
+		return nil
+	}
+	return errors.New("Priority should be one of these: " +
+		"'P1', 'P2', 'P3', 'P4' and 'P5'")
+}
+
+func validateImpactedServices(impactedServices []string) error {
+	if len(impactedServices) > 20 {
+		return errors.New("Impacted services property cannot have services more than 20.")
+	}
+	return nil
+}
+
+func validateStakeholderProperties(stakeholderProperties StakeholderProperties) error {
+	if stakeholderProperties.Message == "" {
+		return errors.New("Message field of stakeholder property cannot be empty.")
+	}
+	if stakeholderProperties.Description != "" && len(stakeholderProperties.Description) > 15000 {
+		return errors.New("Description field of stakeholder property cannot be longer than 15000 characters.")
+	}
+	return nil
+}
+
+func validateIncidentTemplateId(incidentTemplateId string) error {
+	if incidentTemplateId == "" {
+		return errors.New("Incident Template Id property cannot be empty.")
+	} else if len(incidentTemplateId) > 130 {
+		return errors.New("Incident Template Id property cannot be longer than 130 characters.")
+	}
+	return nil
+}

--- a/incident/incident_template_result.go
+++ b/incident/incident_template_result.go
@@ -1,0 +1,38 @@
+package incident
+
+import "github.com/opsgenie/opsgenie-go-sdk-v2/client"
+
+type TemplateIncident struct {
+	Name                  string                `json:"name"`
+	IncidentTemplateId    string                `json:"id"`
+	Message               string                `json:"message"`
+	Description           string                `json:"description,omitempty"`
+	Tags                  []string              `json:"tags,omitempty"`
+	Details               map[string]string     `json:"details,omitempty"`
+	Priority              Priority              `json:"priority"`
+	ImpactedServices      []string              `json:"impactedServices,omitempty"`
+	StakeholderProperties StakeholderProperties `json:"stakeholderProperties"`
+}
+
+type CreateIncidentTemplateResult struct {
+	client.ResultMetadata
+	Result             string `json:"result"`
+	IncidentTemplateId string `json:"id"`
+}
+
+type UpdateIncidentTemplateResult struct {
+	client.ResultMetadata
+	Result             string `json:"result"`
+	IncidentTemplateId string `json:"id"`
+}
+
+type DeleteIncidentTemplateResult struct {
+	client.ResultMetadata
+	Result string `json:"result"`
+}
+
+type GetIncidentTemplateResult struct {
+	client.ResultMetadata
+	IncidentTemplates map[string][]TemplateIncident `json:"data"`
+	Paging            Paging                        `json:"paging"`
+}

--- a/incident/incident_template_test.go
+++ b/incident/incident_template_test.go
@@ -1,0 +1,82 @@
+package incident
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func TestCreateIncidentTemplateRequest_Validate(t *testing.T) {
+	var err error
+	request := &CreateIncidentTemplateRequest{}
+	err = request.Validate()
+	assert.Equal(t, err.Error(), errors.New("Name property cannot be empty.").Error())
+	request.Name = "Incident Template Name-4"
+	err = request.Validate()
+	assert.Equal(t, err.Error(), errors.New("Message property cannot be empty.").Error())
+	request.Message = "Incident Template Message"
+	err = request.Validate()
+	assert.Equal(t, err.Error(), errors.New("Priority should be one of these: 'P1', 'P2', 'P3', 'P4' and 'P5'").Error())
+	request.Priority = "P2"
+	err = request.Validate()
+	assert.Equal(t, err.Error(), errors.New("Message field of stakeholder property cannot be empty.").Error())
+	request.StakeholderProperties = StakeholderProperties{Message: "Stakeholder Message"}
+	err = request.Validate()
+	assert.Nil(t, err)
+
+	assert.Equal(t, request.ResourcePath(), "v1/incident-templates/")
+	assert.Equal(t, request.Method(), http.MethodPost)
+}
+
+func TestUpdateIncidentTemplateRequest_Validate(t *testing.T) {
+	var err error
+	request := &UpdateIncidentTemplateRequest{}
+	err = request.Validate()
+	assert.Equal(t, err.Error(), errors.New("Incident Template Id property cannot be empty.").Error())
+	request.IncidentTemplateId = "929fa6a4-ef29-4bda-8172-135335a9e8f2"
+	err = request.Validate()
+	assert.Equal(t, err.Error(), errors.New("Name property cannot be empty.").Error())
+	request.Name = "Incident Template Name-4"
+	err = request.Validate()
+	assert.Equal(t, err.Error(), errors.New("Message property cannot be empty.").Error())
+	request.Message = "Incident Template Message"
+	err = request.Validate()
+	assert.Equal(t, err.Error(), errors.New("Priority should be one of these: 'P1', 'P2', 'P3', 'P4' and 'P5'").Error())
+	request.Priority = "P2"
+	err = request.Validate()
+	assert.Equal(t, err.Error(), errors.New("Message field of stakeholder property cannot be empty.").Error())
+	request.StakeholderProperties = StakeholderProperties{Message: "Stakeholder Message"}
+	err = request.Validate()
+	assert.Nil(t, err)
+
+	assert.Equal(t, request.ResourcePath(), "v1/incident-templates/929fa6a4-ef29-4bda-8172-135335a9e8f2")
+	assert.Equal(t, request.Method(), http.MethodPut)
+}
+
+func TestDeleteIncidentTemplateRequest_Validate(t *testing.T) {
+	var err error
+	request := &DeleteIncidentTemplateRequest{}
+	err = request.Validate()
+	assert.Equal(t, err.Error(), errors.New("Incident Template Id property cannot be empty.").Error())
+	request.IncidentTemplateId = "929fa6a4-ef29-4bda-8172-135335a9e8f2"
+	err = request.Validate()
+	assert.Nil(t, err)
+
+	assert.Equal(t, request.ResourcePath(), "v1/incident-templates/929fa6a4-ef29-4bda-8172-135335a9e8f2")
+	assert.Equal(t, request.Method(), http.MethodDelete)
+}
+
+func TestGetIncidentTemplateRequest_Validate(t *testing.T) {
+	var err error
+	request := &GetIncidentTemplateRequest{
+		Limit:  20,
+		Offset: 2,
+		Order:  "desc",
+	}
+	err = request.Validate()
+	assert.Nil(t, err)
+
+	assert.Equal(t, request.ResourcePath(), "v1/incident-templates")
+	assert.Equal(t, request.Method(), http.MethodGet)
+}

--- a/incident/request.go
+++ b/incident/request.go
@@ -765,7 +765,7 @@ const (
 )
 
 type Responder struct {
-	Type ResponderType `json:"type, omitempty"`
+	Type ResponderType `json:"type,omitempty"`
 	Name string        `json:"name,omitempty"`
 	Id   string        `json:"id,omitempty"`
 }


### PR DESCRIPTION
* Criteria field return type changed to *og.Criteria from *og.Filter
* Adding incident template API implementation
* go fmt changes

This PR is to make sure original repo master is in sync with Garima's forked repo master.
pull the changes from original repo's master to Garima's forked repo master.